### PR TITLE
Add e1000e (default libvirt qemu nic) support

### DIFF
--- a/utils/mkdisk.sh
+++ b/utils/mkdisk.sh
@@ -95,6 +95,7 @@ mkdir -p "${INITRD_DIR}"
 
 ./lib/modules/*/kernel/net/packet/af_packet.ko.gz
 ./lib/modules/*/kernel/drivers/net/ethernet/intel/e1000/e1000.ko.gz
+./lib/modules/*/kernel/drivers/net/ethernet/intel/e1000e/e1000e.ko.gz
 EOF
 
 # install init script


### PR DESCRIPTION
This is required to not have to hack up the qemu vm unnecessarily. Not strictly required, but useful.